### PR TITLE
del no longer requires a callback

### DIFF
--- a/gulp/build.js
+++ b/gulp/build.js
@@ -86,8 +86,8 @@ gulp.task('other', function () {
     .pipe(gulp.dest(path.join(conf.paths.dist, '/')));
 });
 
-gulp.task('clean', function (done) {
-  $.del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')], done);
+gulp.task('clean', function () {
+  return $.del([path.join(conf.paths.dist, '/'), path.join(conf.paths.tmp, '/')]);
 });
 
 gulp.task('build', ['html', 'fonts', 'other']);


### PR DESCRIPTION
my build were failing due to clean task
