### PR TITLE
Added jshint to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "gulp-useref": "^3.0.8",
     "gulp-util": "^3.0.7",
     "http-proxy-middleware": "^0.13.0",
+    "jshint": "^2.9.1",
     "jshint-loader": "^0.8.3",
     "jshint-stylish": "^2.1.0",
     "karma": "^0.13.22",


### PR DESCRIPTION
I am not sure if it is an issue. But my source came without jshint.

I only added it: 

npm install jshint --save-dev

Thanks for the stack, it is awesome.
